### PR TITLE
chore: add Claude project doc + rules + skills

### DIFF
--- a/.claude/rules/auto-merge-safety.md
+++ b/.claude/rules/auto-merge-safety.md
@@ -1,0 +1,29 @@
+---
+description: Auto-merge in upgrade-provider.yml requires BOTH the github-actions[bot] author filter AND the upgrade-* branch prefix regex. Don't loosen either.
+paths:
+  - ".github/workflows/upgrade-provider.yml"
+  - ".github/workflows/auto-tag.yml"
+---
+
+# Auto-Merge Safety
+
+`upgrade-provider.yml` enables auto-merge **only** when both filters pass:
+
+1. `--author 'app/github-actions'` — bot identity (the action's identity when `GH_TOKEN=GITHUB_TOKEN`).
+2. Branch name matches `^upgrade-(pulumi-terraform-bridge|terraform-provider|pulumi-version)-`.
+
+Together they prevent auto-merging a human PR even if:
+
+- A human commits to a coincidentally-named `upgrade-*` branch (the author check stops that).
+- The bot opens a PR on a non-upgrade branch (the prefix check stops that).
+
+## Don't
+
+- **Don't** loosen the author filter to `--author '*[bot]'` — third-party bots (Renovate, semantic-release, etc.) can match and slip through.
+- **Don't** drop the branch prefix check. Each upgrade type from `pulumi-upgrade-provider-action` controls its own branch name; new template categories require an explicit prefix entry here.
+- **Don't** add auto-merge to non-upgrade flows in this same workflow. Auto-merge for human PRs is a separate decision and should be opt-in per PR via `gh pr merge --auto` by the author.
+- **Don't** use `--admin` on `gh pr merge` — bypassing required reviews defeats the safety net.
+
+## When adding a new upgrade type
+
+If a new bumper opens PRs with a different branch prefix (e.g. `upgrade-go-toolchain-*`), add the prefix to the regex **and** verify the new bumper actually authors as `app/github-actions`. If it uses a different bot identity, the author filter needs widening too — and that's a load-bearing decision; flag it for review rather than silently expanding it.

--- a/.claude/rules/bridge-upgrade-flow.md
+++ b/.claude/rules/bridge-upgrade-flow.md
@@ -1,0 +1,45 @@
+---
+description: Bridge / upstream provider upgrades go in phased PRs (CI uplift → bridge → upstream → SDK regen). Regen commits must contain only generated files.
+paths:
+  - "provider/go.mod"
+  - "provider/go.sum"
+  - ".upgrade-config.yml"
+  - ".github/workflows/upgrade-provider.yml"
+---
+
+# Bridge / Upstream Upgrade Flow
+
+Phased, **one PR per concern**. The git history shows the pattern (e.g. `phase 0 repo + CI uplift`, `phase 2 — bridge v3.105.0 -> v3.127.0`, `phase 3 — terraform-provider-fivetran v1.0.3 -> v1.2.3`).
+
+## Phases
+
+1. **Repo / CI uplift** — anything that's not the dependency bump itself (workflows, Makefile, lint config). Do this first so subsequent regen PRs run on stable infra.
+2. **Bridge bump** — `pulumi-terraform-bridge` version. Often pulls Go toolchain bumps with it.
+3. **Upstream provider bump** — `terraform-provider-fivetran` version.
+4. **Regenerate SDKs** — `make schema build_sdks`, commit the resulting diff under a `chore: regenerate SDKs ...` message. (Or use the `regenerate-sdks` skill.)
+
+## Per phase
+
+```bash
+cd provider && go mod tidy
+make schema build_sdks
+git status        # confirm only the expected files changed
+```
+
+For regen commits, the diff should be **only** generated files. If you see hand-written changes too, split them into a separate commit on the same branch.
+
+## Automated path
+
+`pulumi-upgrade-provider-action` (called by `upgrade-provider.yml`) automates phases 2–4 as separate PRs with these branch prefixes — which is what the auto-merge filter keys off of:
+
+- `upgrade-pulumi-terraform-bridge-*`
+- `upgrade-terraform-provider-*`
+- `upgrade-pulumi-version-*`
+
+## When the bridge removes / renames a symbol
+
+Don't paper over with a shim. Update `provider/resources.go` to the new bridge surface and re-tfgen. Memory `feedback_fix_dont_sidestep` applies: fix at the origin.
+
+## When upstream removes a resource
+
+The schema regen will drop it from `schema.json` and the SDKs. That's a breaking change for downstream Pulumi users — flag it in the PR description and bump a major version segment if appropriate (and you're not already pinned to `v0.x` "anything goes" semantics).

--- a/.claude/rules/generated-code.md
+++ b/.claude/rules/generated-code.md
@@ -1,0 +1,47 @@
+---
+description: Generated code in sdk/ and provider/cmd/pulumi-resource-fivetran/*.json must never be hand-edited — always regenerate via tfgen.
+paths:
+  - "sdk/**"
+  - "provider/cmd/pulumi-resource-fivetran/schema.json"
+  - "provider/cmd/pulumi-resource-fivetran/bridge-metadata.json"
+  - "provider/cmd/pulumi-resource-fivetran/schema-embed.json"
+  - "hk.pkl"
+---
+
+# Generated Code: Don't Hand-Edit
+
+These paths are codegenned and checked in. Always regenerate, never edit by hand:
+
+- `provider/cmd/pulumi-resource-fivetran/schema.json`
+- `provider/cmd/pulumi-resource-fivetran/bridge-metadata.json`
+- `provider/cmd/pulumi-resource-fivetran/schema-embed.json`
+- All of `sdk/nodejs/`, `sdk/python/`, `sdk/go/`, `sdk/dotnet/`
+
+## Regeneration
+
+After editing `provider/resources.go` or bumping the bridge / upstream provider:
+
+```bash
+make schema build_sdks
+```
+
+If diffs look unrelated to your change, run `cd provider && go mod tidy` and retry.
+
+See the `regenerate-sdks` skill for the full ordered flow.
+
+## CI enforcement
+
+`pull-request.yml` runs `make build_$lang` and then verifies a clean worktree, with a small allowlist for version-bearing files:
+
+```
+sdk/.*/pulumi-plugin\.json
+sdk/nodejs/package\.json
+sdk/python/pyproject\.toml
+sdk/go/.*/internal/pulumiUtilities\.go
+```
+
+Anything else dirty after an SDK build = the job fails. Hand edits get caught here.
+
+## hk excludes
+
+`hk.pkl` excludes these paths from formatters/linters. Don't extend hk to "fix" generated code — just regenerate. If the generated output is wrong, fix it upstream (in `provider/resources.go`, the bridge, or the TF provider) and re-tfgen.

--- a/.claude/rules/make-targets.md
+++ b/.claude/rules/make-targets.md
@@ -1,0 +1,40 @@
+---
+description: Makefile uses file targets and .make/ sentinels for incremental builds — CI relies on `make --touch` to skip already-built artifacts. Don't replace with .PHONY shortcuts or helper scripts.
+paths:
+  - "Makefile"
+  - ".github/workflows/**"
+  - ".github/actions/**"
+---
+
+# Make Targets: File Targets + Sentinels
+
+The Makefile is the single entry point for build/test orchestration. It uses **file targets** and **sentinel files** in `.make/` (gitignored) to skip work that's already done.
+
+## Pattern
+
+```make
+schema: .make/schema
+.make/schema: bin/$(TFGEN)
+	$(WORKING_DIR)/bin/$(TFGEN) schema --out provider/cmd/$(PROVIDER)
+	cd provider && VERSION=$(PROVIDER_VERSION) go generate cmd/$(PROVIDER)/main.go
+	@touch $@
+```
+
+Each SDK depends only on `.make/schema` (not on the provider binary), so all four SDKs can build in parallel after a single schema generation.
+
+## CI exploits this
+
+CI uploads the prebuilt `bin/` and `.make/` from a single `prerequisites` job, then dependent jobs download and run:
+
+```bash
+make --touch schema provider           # marks them as up-to-date
+make build_python                      # only the SDK rebuilds
+```
+
+If you replace `.make/` sentinels with `.PHONY:` shortcuts, you'll force every CI shard to rebuild the provider.
+
+## Adding a target
+
+- Multi-step orchestration → Makefile recipe with `&& \` continuations (the existing pattern in `build_python`, `build_nodejs`, etc.).
+- Generated outputs → declare them as file/sentinel targets, not `.PHONY`. This is what makes `make --touch` work in CI.
+- A Python `conftest.py`, `pyproject.toml`, etc. configuring the test framework itself is fine — those are framework-native artifacts, not orchestration.

--- a/.claude/rules/provider-versioning.md
+++ b/.claude/rules/provider-versioning.md
@@ -1,0 +1,45 @@
+---
+description: Provider version comes from `pulumictl get version -o` (the `-o` is mandatory for PyPI). Pre-release tag handling for GoReleaser, npm, and GitHub release. Pull-before-tag rule.
+paths:
+  - "Makefile"
+  - ".github/workflows/release.yml"
+  - ".github/workflows/pull-request.yml"
+  - ".goreleaser.yml"
+  - "provider/pkg/version/**"
+---
+
+# Provider Versioning
+
+## Source of truth
+
+Provider version comes from git tags, resolved by `pulumictl get version -o`:
+
+- `-o` produces a SemVer-compatible version (no `+<sha>` build metadata).
+- PyPI rejects local-version metadata, so `-o` is **mandatory** for the Python SDK build.
+- Local builds default to `PROVIDER_VERSION=1.0.0-alpha.0+dev` (see Makefile).
+
+## In CI
+
+Every job that needs the version sets it itself:
+
+```yaml
+- name: Set provider version
+  run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+```
+
+Don't try to share `$PROVIDER_VERSION` between jobs via artifact — re-running `pulumictl` is cheap and avoids stale-value bugs.
+
+## Pre-release tags (`vX.Y.Z-rc1`, `vX.Y.Z-alpha.1`)
+
+- **GoReleaser**: `GORELEASER_CURRENT_TAG=${GITHUB_REF_NAME}` (the literal pushed tag) — pulumictl's `+<sha>` metadata fails GoReleaser's tag-equals-ref validation.
+- **npm**: published with `--tag next`, not `latest`.
+- **GitHub release**: `prerelease: ${{ contains(github.ref_name, '-') }}`.
+
+## Before tagging
+
+Always `git pull --ff-only origin main` immediately before `git tag` on a shared branch — see memory `feedback_pull_before_tag`. Re-confirm HEAD with `git log -1 --oneline` before pushing the tag.
+
+## Don't
+
+- Hand-edit version strings in generated `sdk/python/pyproject.toml`, `sdk/nodejs/package.json`, `sdk/go/.../pulumiUtilities.go`, `sdk/dotnet/version.txt` — they're regenerated from `PROVIDER_VERSION` on every build.
+- Strip the `v` prefix from the tag for `TFProviderVersion` — `f1ea6e7` showed that doubles the `v` in the SDK.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledPlugins": {
+    "context7@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "gopls@claude-plugins-official": true,
+    "astral@astral-sh": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(make *)",
+      "Bash(go build *)",
+      "Bash(go vet *)",
+      "Bash(go test *)",
+      "Bash(go mod tidy)",
+      "Bash(go mod download)",
+      "Bash(go mod why *)",
+      "Bash(go list *)",
+      "Bash(go env *)",
+      "Bash(golangci-lint run *)",
+      "Bash(mise *)",
+      "Bash(uv *)",
+      "Bash(hk *)",
+      "Bash(yamllint *)",
+      "Bash(actionlint *)",
+      "Bash(taplo *)",
+      "Bash(jq *)",
+      "Bash(pulumi version)",
+      "Bash(pulumi about)",
+      "Bash(pulumictl *)",
+      "Bash(git *)",
+      "Bash(gh pr *)",
+      "Bash(gh run *)",
+      "Bash(gh release *)",
+      "Bash(gh api *)",
+      "Bash(bin/pulumi-tfgen-fivetran schema*)"
+    ],
+    "ask": [
+      "Bash(git tag*)",
+      "Bash(gh pr merge*)",
+      "Bash(gh pr close*)",
+      "Bash(gh release create*)",
+      "Bash(gh release delete*)",
+      "Bash(gh release edit*)",
+      "Bash(gh workflow run*)",
+      "Bash(make clean)",
+      "Bash(goreleaser release*)"
+    ],
+    "deny": [
+      "Bash(mise exec *)",
+      "Bash(git push --force *)",
+      "Bash(git push -f *)",
+      "Bash(git push --force-with-lease *)",
+      "Bash(pip install*)",
+      "Bash(pip3 install*)",
+      "Bash(python -m pip install*)",
+      "Bash(python3 -m pip install*)",
+      "Edit(./sdk/**)",
+      "Write(./sdk/**)",
+      "Edit(./provider/cmd/pulumi-resource-fivetran/schema.json)",
+      "Edit(./provider/cmd/pulumi-resource-fivetran/bridge-metadata.json)",
+      "Edit(./provider/cmd/pulumi-resource-fivetran/schema-embed.json)",
+      "Write(./provider/cmd/pulumi-resource-fivetran/schema.json)",
+      "Write(./provider/cmd/pulumi-resource-fivetran/bridge-metadata.json)",
+      "Write(./provider/cmd/pulumi-resource-fivetran/schema-embed.json)"
+    ]
+  }
+}

--- a/.claude/skills/regenerate-sdks/SKILL.md
+++ b/.claude/skills/regenerate-sdks/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: regenerate-sdks
+description: Regenerate the schema and all four SDKs after a provider/resources.go change, bridge bump, or upstream terraform-provider-fivetran bump. Produces a clean diff suitable for a `chore: regenerate SDKs ...` commit.
+---
+
+# Regenerate SDKs
+
+Use this when:
+
+- You edited `provider/resources.go` (renamed/added a token, mapped a resource, etc.)
+- You bumped `pulumi-terraform-bridge` in `provider/go.mod`
+- You bumped `terraform-provider-fivetran` in `provider/go.mod`
+- An upgrade bot opened a PR and you need to verify / extend it locally
+
+## Steps
+
+1. **Tidy Go modules first.** Stale module state is the #1 cause of "wide unrelated diffs" in the SDK output.
+
+   ```bash
+   cd provider && go mod tidy
+   cd ..
+   ```
+
+2. **Rebuild tfgen and the schema.**
+
+   ```bash
+   make schema
+   ```
+
+   This regenerates `provider/cmd/pulumi-resource-fivetran/{schema.json,bridge-metadata.json,schema-embed.json}`. If `schema.json` is empty or has zero resources, stop — the bridge wiring in `provider/resources.go` is broken and that needs fixing first.
+
+3. **Build all four SDKs in parallel-friendly order.** Each only depends on the schema sentinel:
+
+   ```bash
+   make build_sdks
+   ```
+
+   (Or one at a time: `make build_nodejs`, `make build_python`, `make build_go`, `make build_dotnet`.)
+
+4. **Verify the worktree matches what CI will accept.** CI's `pull-request.yml` allows only this set of post-build dirty files:
+
+   ```
+   sdk/.*/pulumi-plugin\.json
+   sdk/nodejs/package\.json
+   sdk/python/pyproject\.toml
+   sdk/go/.*/internal/pulumiUtilities\.go
+   ```
+
+   Quick local check:
+
+   ```bash
+   git status --porcelain | awk '{print $2}' \
+     | grep -vE '^(sdk/.*/pulumi-plugin\.json|sdk/nodejs/package\.json|sdk/python/pyproject\.toml|sdk/go/.*/internal/pulumiUtilities\.go)$' \
+     | grep -E '^sdk/' || echo "OK — only version-bearing files changed under sdk/"
+   ```
+
+   Anything else dirty under `sdk/` means the regen produced unexpected output.
+
+5. **Smoke-test the Python SDK** (mocked, no Fivetran API needed):
+
+   ```bash
+   make test_python_smoke
+   ```
+
+6. **Commit.** Generated-only commits use the `chore: regenerate ...` prefix matching the existing history:
+
+   ```bash
+   git add provider/cmd/pulumi-resource-fivetran sdk/
+   git commit -m "chore: regenerate schema + SDKs after <reason>"
+   ```
+
+   Don't bundle the regen commit with hand-written changes — keep them as separate commits on the same branch so reviewers can read the regen as a single mechanical diff.
+
+## If the diff looks wrong
+
+- **Huge unrelated comment changes**: ran without `go mod tidy` first. Reset and start at step 1.
+- **Stale `setup.py` instead of `pyproject.toml`**: the Python codegen is producing an old shape — bridge or pulumictl version is too old. Don't hand-edit; fix the version (see commit `9a539ab`).
+- **Doubled `v` in version strings**: `TFProviderVersion` includes a leading `v`. Strip it (commit `f1ea6e7`).
+- **Provider binary rebuilds during a CI SDK shard**: `make --touch schema provider` is missing or out of order. The `make-targets` rule explains the file-target invariant.
+
+## Don't
+
+- Don't hand-edit anything under `sdk/` or `provider/cmd/pulumi-resource-fivetran/*.json` to "fix" output. Fix it upstream — in `provider/resources.go`, the bridge version, or the TF provider version — and re-tfgen.
+- Don't skip step 1. It's the single most common source of noisy regen PRs in this repo's history.

--- a/claude.md
+++ b/claude.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+`pulumi-fivetran` is a [Pulumi](https://www.pulumi.com/) resource provider for [Fivetran](https://www.fivetran.io/), bridged from the upstream Terraform provider [`fivetran/terraform-provider-fivetran`](https://github.com/fivetran/terraform-provider-fivetran) via [`pulumi-terraform-bridge`](https://github.com/pulumi/pulumi-terraform-bridge) v3.
+
+## Architecture
+
+```
+upstream terraform-provider-fivetran (Go module)
+            │
+            ▼
+provider/resources.go ─────► tfgen binary (bin/pulumi-tfgen-fivetran)
+                                   │
+                                   ▼
+                       provider/cmd/pulumi-resource-fivetran/
+                       ├── schema.json
+                       ├── bridge-metadata.json
+                       └── schema-embed.json
+                                   │
+              ┌────────────────────┼────────────────────┬──────────────────┐
+              ▼                    ▼                    ▼                  ▼
+        sdk/nodejs/           sdk/python/            sdk/go/         sdk/dotnet/
+```
+
+- [provider/](provider/) — Go module with bridge wiring ([provider/resources.go](provider/resources.go)) and two binaries: `tfgen` and `pulumi-resource-fivetran`.
+- [sdk/](sdk/) — generated, checked in. See rule `generated-code`.
+- [examples/](examples/) — independent Go module (not in [go.work](go.work)); used by Python integration tests via `GOWORK=off`.
+- [tests/python/](tests/python/) — Pulumi mock-runtime smoke tests.
+- `.make/` — sentinel files for incremental Makefile builds (gitignored). See rule `make-targets`.
+
+## Common commands
+
+```bash
+make build                                                    # tfgen → schema → provider → all 4 SDKs
+make schema                                                   # after editing provider/resources.go
+make build_python                                             # one SDK (also build_nodejs|build_go|build_dotnet)
+make lint
+cd provider && go test -v -short -parallel 10 . ./pkg/...     # provider unit tests
+make test_python_smoke                                        # mocked Python SDK
+make test_python                                              # live integration (needs FIVETRAN_*)
+```
+
+## CI workflows
+
+- [pull-request.yml](.github/workflows/pull-request.yml) — `lint`, `schema-validation`, `go-test`, single `prerequisites` build, then matrix `build_sdk` + `python_tests` consuming the prebuilt artifact.
+- [release.yml](.github/workflows/release.yml) — `v*.*.*` tags. 6-shard goreleaser matrix, then per-language SDK publish. PyPI + npm via OIDC; NuGet gated by `PUBLISH_NUGET=false`.
+- [upgrade-provider.yml](.github/workflows/upgrade-provider.yml) — daily cron; auto-merge gated by author + branch-prefix filters. See rule `auto-merge-safety`.
+- [auto-tag.yml](.github/workflows/auto-tag.yml) — mirrors upstream `terraform-provider-fivetran` tags when `provider/go.mod` changes on `main`. Uses `RELEASE_BOT` GitHub App.
+
+## Where to look
+
+- Provider behavior: [provider/resources.go](provider/resources.go), [provider/pkg/](provider/pkg/)
+- Toolchain: [mise.toml](mise.toml) (dev), [mise.ci.toml](mise.ci.toml) (CI subset — keep shared tools in sync). Pre-commit via `hk` ([hk.pkl](hk.pkl)).
+- Project rules and skills: [.claude/rules/](.claude/rules/), [.claude/skills/](.claude/skills/)
+- Upstream: `fivetran/terraform-provider-fivetran` GitHub; `pulumi-terraform-bridge` v3 docs


### PR DESCRIPTION
## Summary

Adds project-level AI guidance mirrored from `pulumi-astronomer`:

- `claude.md` — project doc (architecture, commands, CI workflow overview)
- `.claude/settings.json` — preserves existing `enabledPlugins` (adds `gopls`); brings in the astronomer permissions block (make/go/pulumi/mise/hk/uv/git/gh allowlist; deny edits to generated files under `sdk/` and `provider/cmd/pulumi-resource-fivetran/*.json`)
- `.claude/rules/` — 5 project rules: auto-merge-safety, bridge-upgrade-flow, generated-code, make-targets, provider-versioning
- `.claude/skills/regenerate-sdks/SKILL.md` — repeatable SDK regen workflow

## Test plan
- [x] `jq .` validates the settings JSON file
- [x] All paths under `.claude/` resolve as listed in the body
- [ ] Reads correctly when reviewed manually for fivetran-specific accuracy

Wave 1 / PR2 of a multi-PR modernization. Independent of PR1 (toolchain).

> Note: \`.claude/\` is gitignored on \`main\` until PR1 (\`chore/modernize-toolchain\`) merges. Files were force-added so they show up in this PR's diff. After PR1 lands and the gitignore exclusion is removed, no further action needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)