### PR TITLE
ci: parallelize PR + release pipelines, add auto-tag mirror, mocked Python smoke tests

### DIFF
--- a/.github/actions/download-prerequisites/action.yml
+++ b/.github/actions/download-prerequisites/action.yml
@@ -1,0 +1,26 @@
+name: Download prerequisites
+description: Downloads pre-built provider binaries and schema-embed.json.
+
+runs:
+  using: composite
+  steps:
+    - name: Download prerequisites bin
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: prerequisites-bin
+        path: bin
+
+    - name: Restore executable permissions
+      shell: bash
+      run: chmod +x $(< bin/executables.txt)
+
+    - name: Remove executables list
+      shell: bash
+      run: rm bin/executables.txt
+
+    - name: Download schema-embed.json
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        pattern: schema-embed.*
+        merge-multiple: true
+        path: provider/cmd/pulumi-resource-fivetran

--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -1,0 +1,36 @@
+name: Setup mise (CI subset)
+description: |
+  Install only the trimmed CI tool set defined in mise.ci.toml. Stages the
+  CI config in $RUNNER_TEMP so mise-action's `mise install` reads from there
+  instead of the full repo-root mise.toml. Tools land on PATH globally.
+
+inputs:
+  cache_save:
+    description: |
+      Whether this job should write the mise cache. Set to "true" on exactly
+      one job per workflow (typically `prerequisites`); "false" elsewhere so
+      parallel jobs only restore.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Stage CI mise config
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/mise-ci"
+        cp "$GITHUB_WORKSPACE/mise.ci.toml" "$RUNNER_TEMP/mise-ci/mise.toml"
+
+    - name: Setup mise
+      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+      env:
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
+      with:
+        version: 2026.3.7
+        working_directory: ${{ runner.temp }}/mise-ci
+        cache_save: ${{ inputs.cache_save }}
+        # Key on platform + mise.ci.toml hash only. Omitting {{version}}
+        # keeps the cache valid across the near-daily mise CLI releases — it
+        # would otherwise invalidate every time we bump the pinned version.
+        cache_key: "mise-{{platform}}-{{file_hash}}"

--- a/.github/actions/upload-prerequisites/action.yml
+++ b/.github/actions/upload-prerequisites/action.yml
@@ -1,0 +1,25 @@
+name: Upload prerequisites
+description: Uploads pre-built provider binaries and schema-embed.json as workflow artifacts.
+
+runs:
+  using: composite
+  steps:
+    - name: Capture executable permissions
+      shell: bash
+      run: find bin -type f -executable > bin/executables.txt
+
+    - name: Upload prerequisites bin
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: prerequisites-bin
+        path: bin/*
+        retention-days: 1
+        if-no-files-found: error
+
+    - name: Upload schema-embed.json
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: schema-embed.json
+        path: provider/cmd/pulumi-resource-fivetran/schema-embed.json
+        retention-days: 1
+        if-no-files-found: error

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,54 @@
+name: auto-tag-upstream-bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - provider/shim/go.mod
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    name: tag-upstream-bump
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint pulumi-release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      - name: Checkout with App token + tags
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Decide whether to tag
+        id: decide
+        run: |
+          set -euo pipefail
+          UPSTREAM=$(awk '/terraform-provider-fivetran / && $1 != "//" {print $2; exit}' provider/shim/go.mod)
+          echo "Upstream provider version: '$UPSTREAM'"
+          if [[ ! "$UPSTREAM" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "Not a release version (likely pseudoversion); skipping."
+            exit 0
+          fi
+          if git rev-parse --verify "refs/tags/$UPSTREAM" >/dev/null 2>&1; then
+            echo "Tag $UPSTREAM already exists; nothing to do."
+            exit 0
+          fi
+          echo "tag=$UPSTREAM" >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        if: steps.decide.outputs.tag != ''
+        env:
+          TAG: ${{ steps.decide.outputs.tag }}
+        run: |
+          git config user.name 'pulumi-release-bot[bot]'
+          git config user.email 'pulumi-release-bot[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "chore(release): $TAG (mirror upstream terraform-provider-fivetran)"
+          git push origin "$TAG"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,6 +19,8 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,6 +45,8 @@ jobs:
   schema_validation:
     name: schema-validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -64,6 +68,8 @@ jobs:
   go_test:
     name: go-test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -96,6 +102,8 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -133,6 +141,8 @@ jobs:
     name: build_sdk
     runs-on: ubuntu-latest
     needs: prerequisites
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:
@@ -211,6 +221,8 @@ jobs:
     needs:
       - prerequisites
       - build_sdk
+    permissions:
+      contents: read
     # The fivetran-live environment gate was intentionally dropped so PRs run
     # end-to-end without a required-reviewer pause. The `pull_request` trigger
     # means fork PRs run with fork-owned code and no secrets — make test_python

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,137 +7,45 @@ on:
       - .devcontainer
       - examples
 
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
-  build_sdk:
-    name: build_sdk
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        dotnetversion:
-          - 8.0.x
-        goversion:
-          - 1.25.x
-        nodeversion:
-          - 20.x
-        pythonversion:
-          - "3.11"
-        javaversion:
-          - "11"
-        language:
-          - nodejs
-          - python
-          # - dotnet
-          - go
-          # - java
-
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Unshallow clone for tags
-        run: git fetch --prune --unshallow --tags
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{matrix.goversion}}
-
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
-        with:
-          repo: pulumi/pulumictl
-
-      - name: Install pulumi
-        uses: pulumi/actions@v5
-
-      - if: ${{ matrix.language == 'nodejs'}}
-        name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{matrix.nodeversion}}
-          registry-url: https://registry.npmjs.org
-
-      - if: ${{ matrix.language == 'dotnet'}}
-        name: Setup DotNet
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{matrix.dotnetversion}}
-
-      - if: ${{ matrix.language == 'python'}}
-        name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{matrix.pythonversion}}
-
-      - if: ${{ matrix.language == 'java'}}
-        name: Setup Java
-        uses: actions/setup-java@v4
-        with:
-          cache: gradle
-          distribution: temurin
-          java-version: ${{matrix.javaversion}}
-
-      - name: Build SDK
-        run: make build_${{ matrix.language }}
-
-      - name: Check worktree clean
-        run: |
-          git update-index -q --refresh
-          if ! git diff-files --quiet; then
-              >&2 echo "error: working tree is not clean, aborting!"
-              git status
-              git diff
-              exit 1
-          fi
+  # ── parallel, no dependencies ─────────────────────────────────────────────
 
   lint:
     name: lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: 1.25.x
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
 
-      - name: Install golangci-lint v2
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | \
-            sh -s -- -b $(go env GOPATH)/bin v2.5.0
-          golangci-lint --version
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
 
       - name: Run golangci-lint
-        # Lint library packages only; cmd/ depends on schema-embed.json which is generated at build time.
+        # Lint library packages only; cmd/ depends on schema-embed.json which is generated.
         run: cd provider && golangci-lint run --path-prefix provider -c ../.golangci.yml . ./pkg/...
-
-  unit_test:
-    name: unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v4
-
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.25.x
-
-      - name: go vet
-        # Exclude cmd/ packages: they embed schema-embed.json which is generated at build time.
-        run: cd provider && go vet . ./pkg/...
-
-      - name: go test
-        # Exclude cmd/ packages for the same reason (schema-embed.json not present without make generate).
-        run: cd provider && go test -v -short -parallel 10 . ./pkg/...
 
   schema_validation:
     name: schema-validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Validate schema is valid JSON
         run: |
@@ -149,6 +57,199 @@ jobs:
           COUNT=$(jq '.resources | length' provider/cmd/pulumi-resource-fivetran/schema.json)
           echo "Schema contains $COUNT resources"
           if [ "$COUNT" -eq 0 ]; then
-            echo "ERROR: Schema has zero resources - something went wrong with generation"
+            echo "ERROR: Schema has zero resources"
             exit 1
           fi
+
+  go_test:
+    name: go-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
+
+      - name: go vet
+        # Exclude cmd/: depends on schema-embed.json which is generated at build time.
+        run: cd provider && go vet . ./pkg/...
+
+      - name: go test
+        run: cd provider && go test -v -short -parallel 10 . ./pkg/...
+
+  # ── prerequisites: build provider once, share artifact ────────────────────
+
+  prerequisites:
+    name: prerequisites
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
+        with:
+          cache_save: "true" # This job populates the mise cache for the rest of the workflow.
+
+      - name: Set provider version
+        run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+
+      - name: Build provider
+        run: make prepare_local_workspace
+
+      - name: Upload prerequisites
+        uses: ./.github/actions/upload-prerequisites
+
+  # ── build SDKs (matrix, needs prerequisites) ──────────────────────────────
+
+  build_sdk:
+    name: build_sdk
+    runs-on: ubuntu-latest
+    needs: prerequisites
+    strategy:
+      fail-fast: true
+      matrix:
+        language:
+          - nodejs
+          - python
+          - go
+          - dotnet
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        if: matrix.language == 'go'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
+
+      - name: Set provider version
+        run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+
+      - name: Download prerequisites
+        uses: ./.github/actions/download-prerequisites
+
+      - name: Restore makefile progress
+        # Marks schema + provider as done so make build_$lang skips rebuilding them.
+        run: make --touch schema provider
+
+      - name: Build SDK
+        run: make build_${{ matrix.language }}
+
+      - name: Check worktree clean
+        # Inline replacement for unmaintained pulumi/git-status-check-action.
+        # Version-bearing files are regenerated per build; everything else must match.
+        run: |
+          set -euo pipefail
+          ALLOWED='^(sdk/.*/pulumi-plugin\.json|sdk/nodejs/package\.json|sdk/python/pyproject\.toml|sdk/go/.*/internal/pulumiUtilities\.go)$'
+          UNEXPECTED=$(git status --porcelain | awk '{print $2}' | grep -vE "$ALLOWED" || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Unexpected worktree changes after SDK build:"
+            printf '%s\n' "$UNEXPECTED"
+            git --no-pager diff --stat
+            exit 1
+          fi
+
+      - name: Compress SDK
+        if: matrix.language == 'python'
+        run: tar -czf sdk/python.tar.gz -C sdk/python .
+
+      - name: Upload Python SDK
+        if: matrix.language == 'python'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-sdk
+          path: sdk/python.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+  # ── Python tests (needs prerequisites + python SDK) ───────────────────────
+
+  python_tests:
+    name: python-tests
+    runs-on: ubuntu-latest
+    needs:
+      - prerequisites
+      - build_sdk
+    # The fivetran-live environment gate was intentionally dropped so PRs run
+    # end-to-end without a required-reviewer pause. The `pull_request` trigger
+    # means fork PRs run with fork-owned code and no secrets — make test_python
+    # skips itself when FIVETRAN_APIKEY is unset.
+    env:
+      FIVETRAN_APIKEY: ${{ secrets.FIVETRAN_APIKEY }}
+      FIVETRAN_APISECRET: ${{ secrets.FIVETRAN_APISECRET }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
+
+      - name: Set provider version
+        run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+
+      - name: Download prerequisites
+        uses: ./.github/actions/download-prerequisites
+
+      - name: Download Python SDK
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-sdk
+          path: sdk
+
+      - name: Extract Python SDK
+        run: mkdir -p sdk/python && tar -xzf sdk/python.tar.gz -C sdk/python
+
+      - name: Restore makefile progress
+        # Touch schema → provider → build_python in order so each target's output
+        # file is newer than its prerequisite and make skips all rebuilds.
+        run: make --touch schema provider build_python
+
+      - name: Python SDK smoke tests
+        run: make test_python_smoke
+
+      - name: Live integration tests
+        run: make test_python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,166 +1,281 @@
 name: release
+
 on:
   push:
     tags:
       - v*.*.*
+    paths-ignore:
+      - docs
+      - .devcontainer
+      - examples
+
 env:
-  # THIS GITHUB_TOKEN IS A REQUIREMENT TO BE ABLE TO WRITE TO GH RELEASES
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  # IF YOU NEED TO PUBLISH A NPM PACKAGE THEN ENSURE A NPM_TOKEN SECRET IS SET
-  # AND PUBLISH_NPM: TRUE. IF YOU WANT TO PUBLISH TO A PRIVATE NPM REGISTRY
-  # THEN ENSURE THE NPM_REGISTRY_URL IS CHANGED
-  # NODE_AUTH_TOKEN: ${{ YOUR NPM TOKEN HERE }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   PUBLISH_NPM: true
   NPM_REGISTRY_URL: https://registry.npmjs.org
-  # IF YOU NEED TO PUBLISH A NUGET PACKAGE THEN ENSURE AN NUGET_PUBLISH_KEY
-  # SECRET IS SET AND PUBLISH_NUGET: TRUE. IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
-  # NPM REGISTRY THEN ENSURE THE NPM_REGISTRY_URL IS CHANGED
-  # NUGET_PUBLISH_KEY: ${{ YOUR NUGET PUBLISH KEY HERE }}
-  #NUGET_FEED_URL: https://api.nuget.org/v3/index.json
+  NUGET_PUBLISH_KEY: ${{ secrets.NUGET_PUBLISH_KEY }}
+  NUGET_FEED_URL: https://api.nuget.org/v3/index.json
   PUBLISH_NUGET: false
-  # IF YOU NEED TO PUBLISH A PYPI PACKAGE THEN ENSURE AN PYPI_API_TOKEN
-  # SECRET IS SET AND PUBLISH_PYPI: TRUE. IF YOU WANT TO PUBLISH TO AN ALTERNATIVE
-  # PYPI REGISTRY THEN ENSURE THE PYPI_REPOSITORY_URL IS SET. IF YOU ARE USING AN API_TOKEN THEN
-  # YOU DO NOT NEED TO CHANGE THE PYPI_USERNAME (__token__) , IF YOU ARE USING PASSWORD AUTHENTICATION THEN YOU WILL
-  # NEED TO CHANGE TO USE THE CORRECT PASSWORD
-  #PYPI_PASSWORD: ${{ YOUR PYPI PASSWORD HERE }}
-  #PYPI_USERNAME: "YOUR PYPI USERNAME HERE"
-  #PYPI_REPOSITORY_URL: ""
   PUBLISH_PYPI: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
-  publish_binary:
-    name: publish
+  # ── build provider once, share artifact ───────────────────────────────────
+
+  prerequisites:
+    name: prerequisites
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
-      - name: Install Go
-        uses: actions/setup-go@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{matrix.goversion}}
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
         with:
-          repo: pulumi/pulumictl
-      - name: Set PreRelease Version
-        run: echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic)" >> $GITHUB_ENV
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          args: -p 3 release --clean
+          cache_save: "true" # This job populates the mise cache for the rest of the workflow.
+
+      - name: Set provider version
+        run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+
+      - name: Build provider
+        run: make prepare_local_workspace
+
+      - name: Upload prerequisites
+        uses: ./.github/actions/upload-prerequisites
+
+  # ── matrix-build cross-platform binaries (parallel, needs prerequisites) ───
+  # Splitting the GoReleaser cross-compile into 6 parallel shards (one per
+  # GOOS/GOARCH) drops the build wall-clock from ~8m to ~1.5m. We use
+  # `goreleaser build --single-target` per shard, then publish_release
+  # archives + uploads the assembled binaries.
+
+  publish_binary:
+    name: build-binary
+    runs-on: ubuntu-latest
+    needs: prerequisites
     strategy:
       fail-fast: true
       matrix:
-        goversion:
-          - 1.23.x
-  publish_sdk:
-    name: Publish SDKs
-    runs-on: ubuntu-latest
-    needs: publish_binary
-    permissions:
-      id-token: write
+        include:
+          - { goos: linux, goarch: amd64 }
+          - { goos: linux, goarch: arm64 }
+          - { goos: darwin, goarch: amd64 }
+          - { goos: darwin, goarch: arm64 }
+          - { goos: windows, goarch: amd64 }
+          - { goos: windows, goarch: arm64 }
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Unshallow clone for tags
         run: git fetch --prune --unshallow --tags
 
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: ${{ matrix.goversion }}
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
 
-      - name: Install pulumictl
-        uses: jaxxstorm/action-install-gh-release@v1.11.0
+      - name: Cache Go build cache (per goos/goarch)
+        # setup-go caches GOPATH/pkg/mod and ~/.cache/go-build keyed by go.sum,
+        # but its key is platform-agnostic. Cross-compiles for separate GOOS/
+        # GOARCH thrash that single cache. A per-shard cache keyed by goos/
+        # goarch + go.sum keeps each shard warm across same-go.sum releases.
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          repo: pulumi/pulumictl
+          path: ~/.cache/go-build
+          key: gobuild-${{ runner.os }}-${{ matrix.goos }}-${{ matrix.goarch }}-${{ hashFiles('provider/go.sum') }}
+          restore-keys: |
+            gobuild-${{ runner.os }}-${{ matrix.goos }}-${{ matrix.goarch }}-
 
-      - name: Install pulumi
-        uses: pulumi/actions@v5
+      - name: Set GoReleaser tag
+        # Use the literal pushed tag. pulumictl appends `+<sha>` build metadata to
+        # pre-release versions, which fails GoReleaser's tag-equals-ref validation.
+        run: echo "GORELEASER_CURRENT_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
 
-      - if: ${{ matrix.language == 'nodejs'}}
-        name: Setup Node
-        uses: actions/setup-node@v4
+      - name: Download prerequisites
+        # Pulls the prebuilt schema-embed.json so we can skip the `make schema`
+        # GoReleaser before-hook (it's already done once in the prerequisites job).
+        uses: ./.github/actions/download-prerequisites
+
+      - name: Build binary (single target)
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
         with:
-          node-version: ${{matrix.nodeversion}}
-          registry-url: ${{env.NPM_REGISTRY_URL}}
+          version: '~> v2'
+          args: build --single-target --clean --skip=before
 
-      - if: ${{ matrix.language == 'dotnet'}}
-        name: Setup DotNet
-        uses: actions/setup-dotnet@v4
+      - name: Archive binary
+        # Match the existing release-asset naming so consumers (Pulumi plugin
+        # registry, etc.) keep finding the binaries:
+        #   pulumi-resource-fivetran-vX.Y.Z-{os}-{arch}.{tar.gz|zip}
+        run: |
+          set -euo pipefail
+          BIN_DIR=$(find dist -type d -name "*${{ matrix.goos }}_${{ matrix.goarch }}*" | head -n1)
+          if [ -z "$BIN_DIR" ]; then
+            echo "::error::Could not locate built binary directory under dist/"
+            ls -la dist || true
+            exit 1
+          fi
+          cp LICENSE README.md "$BIN_DIR/"
+          BIN_NAME="pulumi-resource-fivetran"
+          ARCHIVE_BASENAME="${BIN_NAME}-${GORELEASER_CURRENT_TAG}-${{ matrix.goos }}-${{ matrix.goarch }}"
+          mkdir -p "${RUNNER_TEMP}/release"
+          cd "$BIN_DIR"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip -r "${RUNNER_TEMP}/release/${ARCHIVE_BASENAME}.zip" .
+          else
+            tar czf "${RUNNER_TEMP}/release/${ARCHIVE_BASENAME}.tar.gz" .
+          fi
+
+      - name: Upload archive
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          dotnet-version: ${{matrix.dotnetversion}}
+          name: archive-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ${{ runner.temp }}/release/
+          retention-days: 1
+          if-no-files-found: error
 
-      - if: ${{ matrix.language == 'java'}}
-        name: Setup Java
-        uses: actions/setup-java@v4
+  # ── assemble per-platform archives + checksums into a GitHub release ───────
+
+  publish_release:
+    name: publish-release
+    runs-on: ubuntu-latest
+    needs:
+      - prerequisites
+      - publish_binary
+    permissions:
+      contents: write
+    steps:
+      - name: Download all archives
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: gradle
-          distribution: temurin
-          java-version: ${{matrix.javaversion}}
+          path: release-assets/
+          pattern: archive-*
+          merge-multiple: true
 
-      - if: ${{ matrix.language == 'python'}}
-        name: Setup Python
-        uses: actions/setup-python@v5
+      - name: Generate checksums.txt
+        working-directory: release-assets
+        run: sha256sum * > checksums.txt
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
-          python-version: ${{matrix.pythonversion}}
+          files: release-assets/*
+          fail_on_unmatched_files: true
+          # `prerelease: auto` matches GoReleaser's previous behavior (pre-release
+          # tag like vX.Y.Z-rc1 → prerelease, otherwise stable).
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
-      - name: Set Provider Version
-        run: echo "PROVIDER_VERSION=$(pulumictl get version --language generic)" >> $GITHUB_ENV
+  # ── build and publish SDKs (matrix, needs prerequisites + binary) ──────────
+
+  publish_sdk:
+    name: publish-sdk
+    runs-on: ubuntu-latest
+    needs:
+      - prerequisites
+      - publish_release
+    permissions:
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        language:
+          - nodejs
+          - python
+          - go
+          - dotnet
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Unshallow clone for tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: provider/go.mod
+          cache-dependency-path: |
+            provider/go.sum
+            provider/shim/go.sum
+            sdk/go.sum
+            examples/go.sum
+
+      - name: Setup mise (CI subset)
+        uses: ./.github/actions/setup-mise
+
+      - name: Set provider version
+        run: echo "PROVIDER_VERSION=$(pulumictl get version -o)" >> "$GITHUB_ENV"
+
+      - name: Configure npm registry
+        if: matrix.language == 'nodejs'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.x
+          registry-url: ${{ env.NPM_REGISTRY_URL }}
+
+      - name: Download prerequisites
+        uses: ./.github/actions/download-prerequisites
+
+      - name: Restore makefile progress
+        # Marks schema + provider as done so make build_$lang skips rebuilding them.
+        run: make --touch schema provider
 
       - name: Build SDK
         run: make build_${{ matrix.language }}
 
       - name: Check worktree clean
+        # Inline replacement for unmaintained pulumi/git-status-check-action.
+        # Version-bearing files are regenerated per build; everything else must match.
         run: |
-          git update-index -q --refresh
-          if ! git diff-files --quiet; then
-              >&2 echo "error: working tree is not clean, aborting!"
-              git status
-              git diff
-              exit 1
+          set -euo pipefail
+          ALLOWED='^(sdk/.*/pulumi-plugin\.json|sdk/nodejs/package\.json|sdk/python/pyproject\.toml|sdk/go/.*/internal/pulumiUtilities\.go)$'
+          UNEXPECTED=$(git status --porcelain | awk '{print $2}' | grep -vE "$ALLOWED" || true)
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Unexpected worktree changes after SDK build:"
+            printf '%s\n' "$UNEXPECTED"
+            git --no-pager diff --stat
+            exit 1
           fi
 
-      - if: ${{ matrix.language == 'python' && env.PUBLISH_PYPI == 'true' }}
-        name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish package to PyPI
+        if: matrix.language == 'python' && env.PUBLISH_PYPI == 'true'
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
-          packages-dir: ${{github.workspace}}/sdk/python/bin/dist
-          skip-existing: true
+          packages-dir: ${{ github.workspace }}/sdk/python/bin/dist
 
-      - if: ${{ matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true' }}
-        uses: JS-DevTools/npm-publish@v3
-        with:
-          access: "public"
-          token: ${{ env.NPM_TOKEN }}
-          package: ${{github.workspace}}/sdk/nodejs/bin/package.json
-
-      - if: ${{ matrix.language == 'dotnet' && env.PUBLISH_NUGET == 'true' }}
-        name: publish nuget package
+      - name: Publish package to npm
+        # OIDC trusted publishing (no token). Requires the npm package to have a
+        # trusted publisher configured for this repo + workflow, and id-token: write
+        # on this job (set above). Trusted publishing needs npm >= 11.5.1, but
+        # Node 22 LTS ships npm 10.x and `npm install -g npm@latest` hits a
+        # known self-upgrade MODULE_NOT_FOUND bug — invoking via `npx` runs a
+        # clean npm out of the npx cache and avoids it. Pre-release tags
+        # (v*.*.*-*) publish to the `next` dist-tag so they don't claim `latest`.
+        if: matrix.language == 'nodejs' && env.PUBLISH_NPM == 'true'
+        working-directory: ${{ github.workspace }}/sdk/nodejs/bin
         run: |
-          dotnet nuget push ${{github.workspace}}/sdk/dotnet/bin/Debug/*.nupkg \
-            -s ${{ env.NUGET_FEED_URL }} -k ${{ env.NUGET_PUBLISH_KEY }}
-          echo "done publishing packages"
-
-    strategy:
-      fail-fast: true
-      matrix:
-        dotnetversion:
-          - 8.0.x
-        goversion:
-          - 1.23.x
-        nodeversion:
-          - 20.x
-        pythonversion:
-          - "3.11"
-        javaversion:
-          - "11"
-        language:
-          - nodejs
-          - python
-          - dotnet
-          - go
+          if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
+            npx -y npm@latest publish --provenance --access public --tag next
+          else
+            npx -y npm@latest publish --provenance --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
       - .devcontainer
       - examples
 
+permissions:
+  contents: read
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PUBLISH_NPM: true
@@ -25,6 +28,8 @@ jobs:
   prerequisites:
     name: prerequisites
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -66,6 +71,8 @@ jobs:
     name: build-binary
     runs-on: ubuntu-latest
     needs: prerequisites
+    permissions:
+      contents: read
     strategy:
       fail-fast: true
       matrix:
@@ -193,6 +200,7 @@ jobs:
       - prerequisites
       - publish_release
     permissions:
+      contents: read
       id-token: write
     strategy:
       fail-fast: true

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -1,8 +1,6 @@
 name: Upgrade provider
 on:
-  issues:
-    types:
-      - opened
+  workflow_dispatch:
   schedule:
     - cron: '0 5 * * *'
 env:
@@ -16,7 +14,50 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - name: Call upgrade provider action
-        uses: pulumi/pulumi-upgrade-provider-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Fetch main
+        run: git fetch --depth=1 origin main:main
+        shell: bash
+
+      - name: Setup mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        env:
+          MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: 30s
         with:
-          kind: all
+          version: 2026.3.7
+          cache_save: false
+          cache_key: "mise-full-{{platform}}-{{file_hash}}"
+
+      - name: Install upgrade-provider
+        run: go install github.com/pulumi/upgrade-provider@main
+        shell: bash
+
+      - name: Set up git identity
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+        shell: bash
+
+      - name: Run upgrade-provider
+        run: upgrade-provider "$GITHUB_REPOSITORY" --kind=all --allow-missing-docs=true --repo-path=.
+        shell: bash
+
+      - name: Enable auto-merge on upgrade PR
+        # safety filter — both bot author + branch prefix required
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(git branch --show-current)
+          case "$BRANCH" in
+            upgrade-pulumi-terraform-bridge-*|upgrade-terraform-provider-*|upgrade-pulumi-version-*) ;;
+            *) echo "branch $BRANCH not an upgrade branch; skipping"; exit 0 ;;
+          esac
+          AUTHOR=$(gh pr view --json author --jq .author.login)
+          if [ "$AUTHOR" != "app/github-actions" ]; then
+            echo "PR author is $AUTHOR (not app/github-actions); skipping"
+            exit 0
+          fi
+          gh pr merge --auto --squash --delete-branch
+        shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,11 @@ sdk/java/gradlew.bat
 
 sdk/python/venv
 
+# Python test artifacts (created by `make test_python_smoke`)
+**/__pycache__/
+*.py[cod]
+.venv/
+**/.venv/
+
 # Ignore local build tracking directory
 .make

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,245 +1,61 @@
-# Plan: Automate Provider Updates + Quality Uplift for pulumi-fivetran
+# Plan: pulumi-fivetran
 
-**Last updated**: 2026-04-16
-**Working branch**: `claude/automate-provider-updates-2DiaM`
+**Last updated**: 2026-04-30
 
----
+## Status
 
-## Status Summary
+The repo modernization tracking the [pulumi-astronomer template](../pulumi-astronomer)
+has landed in four PRs:
 
-| Phase | Description | Status |
+| PR | Wave | Scope |
 |---|---|---|
-| Phase 0 | Repo uplift (lint, tests, schema validation CI) | **DONE — needs PR + merge** |
-| Phase 1 | Delete 14 stale branches | Not started |
-| Phase 2 | Bridge upgrade v3.111.0 → v3.126.0 | Not started (blocked on Phase 0 merge) |
-| Phase 3 | Provider upgrade v1.9.4 → v1.9.29 | Not started (blocked on Phase 2 merge) |
+| #46 (merged) | 1 | Toolchain — mise.toml + mise.ci.toml + hk.pkl pre-commit, drop .go-version |
+| #45 (merged) | 1 | AI — `claude.md` + `.claude/{settings,rules,skills}` |
+| #47 (merged) | 2 | Build — Makefile rewrite, RespectSchemaVersion + PyProject in resources.go, SDK regen |
+| #48 (open)   | 2 | CI — parallel pull-request/release pipelines, OIDC trusted publishing, mocked Python smoke tests, auto-tag.yml |
 
----
+**Tag cleanup**: deleted v1.9.4 / v1.9.5 / v1.9.6 / v1.9.7 (releases that
+never had passing CI) along with their orphaned draft GitHub releases.
+Latest valid tag is `v1.5.1`.
 
-## Phase 0 — Repo Uplift ✅ COMPLETE (on branch, no PR yet)
+## Outstanding
 
-All changes are committed on `claude/automate-provider-updates-2DiaM` (4 commits ahead of main).
-**Next action**: Create a PR from this branch to `main`, get it merged.
+### Setup follow-ups (after PR #48 merges)
+- **OIDC trusted publishing** — configure Trusted Publishers on
+  [npmjs.com](https://docs.npmjs.com/trusted-publishers) for
+  `@ryan-pip/pulumi-fivetran` and on
+  [pypi.org](https://docs.pypi.org/trusted-publishers/) for
+  `pulumi_provider_fivetran` before the next release tag is cut.
+- **auto-tag.yml prereqs** — provision a `pulumi-release-bot` GitHub App,
+  install on this repo, and set `vars.RELEASE_BOT_APP_ID` +
+  `secrets.RELEASE_BOT_PRIVATE_KEY`. Without these, `auto-tag.yml` will
+  fail to mint its app token.
 
-### What was done
-
-**`.golangci.yml`** — Rewrote for golangci-lint v2 format. Removed 6 deprecated linters
-(`megacheck`, `deadcode`, `structcheck`, `varcheck`, `golint`, `interfacer`), replaced with
-modern equivalents (`staticcheck`, `unused`, `revive`). Added `exclude-dirs: [cmd]` because
-`cmd/` embeds `schema-embed.json` which is only present after `make generate`.
-
-**`.github/workflows/pull-request.yml`** — Added three new jobs:
-- `lint`: installs golangci-lint v2.5.0 via shell script, runs on `provider/` and `provider/pkg/...`
-- `unit_test`: runs `go vet` and `go test -v -short -parallel 10` (excludes `cmd/`)
-- `schema_validation`: validates `schema.json` is valid JSON and has > 0 resources
-Also bumped `actions/setup-go` from v4 → v5.
-
-**`.github/workflows/upgrade-provider.yml`** — Updated action from `@v0.0.15` to `@v1`.
-
-**`provider/go.mod`** — Removed `github.com/pulumi/pulumi-terraform-bridge/pf v0.49.0`
-(the standalone `/pf` module was deleted upstream at bridge v3.97.0; the functionality moved
-into the main `v3` module at `pkg/pf/tfbridge`). The `provider/resources.go` import already
-uses the correct path `github.com/pulumi/pulumi-terraform-bridge/v3/pkg/pf/tfbridge`.
-
-### To create the PR
+### Provider upgrade v1.9.4 → latest
+The new [upgrade-provider.yml](.github/workflows/upgrade-provider.yml)
+runs daily at 05:00 UTC and will open `upgrade-terraform-provider-fivetran-*`
+PRs automatically. Auto-merge fires when CI is green (gated on bot author +
+branch-prefix safety filters). Manual fallback:
 
 ```bash
-git checkout claude/automate-provider-updates-2DiaM
-# No further changes needed — everything is committed and pushed
-# Create PR via GitHub MCP tools or gh CLI:
-gh pr create \
-  --base main \
-  --title "ci: add lint, unit-test, schema-validation jobs; fix deprecated golangci linters" \
-  --body "..."
+upgrade-provider ryan-pip/pulumi-fivetran --kind=provider --target-version=v1.9.X
 ```
 
----
-
-## Phase 1 — Delete 14 Stale Branches
-
-Can run any time, independent of other phases.
+### First post-modernization tag
+Once the provider upgrade lands, decide on the new tag (e.g., `v2.0.0` to
+signal the publish-pipeline change, or resume the `v1.9.X` line). Confirm
+Trusted Publishers are configured first, then:
 
 ```bash
-for branch in \
-  upgrade-pulumi-terraform-bridge-to-v3.91.0-98836590 \
-  upgrade-pulumi-terraform-bridge-to-v3.97.1-ci \
-  upgrade-pulumi-terraform-bridge-to-v3.98.0-ci \
-  upgrade-terraform-provider-fivetran-to-v1.3.3-78652080 \
-  upgrade-terraform-provider-fivetran-to-v1.4.0-ci \
-  upgrade-terraform-provider-fivetran-to-v1.4.0 \
-  upgrade-terraform-provider-fivetran-to-v1.4.1-ci \
-  upgrade-terraform-provider-fivetran-to-v1.4.2-ci \
-  upgrade-terraform-provider-fivetran-to-v1.4.2 \
-  upgrade-terraform-provider-fivetran-to-v1.5.0-ci \
-  upgrade-terraform-provider-fivetran-to-v1.5.0 \
-  upgrade-terraform-provider-fivetran-to-v1.5.1-ci \
-  upgrade-terraform-provider-fivetran-to-v1.5.1 \
-  upgrade-terraform-provider-fivetran-to-v1.9.4; do
-  git push origin --delete "$branch"
-done
+git pull --ff-only origin main
+git log -1 --oneline   # confirm HEAD
+git tag -a vX.Y.Z -m 'release vX.Y.Z'
+git push origin vX.Y.Z
 ```
 
----
+## Reference
 
-## Phase 2 — Bridge Upgrade v3.111.0 → v3.126.0
-
-**Blocked until Phase 0 PR is merged to main.**
-Branch: `upgrade-bridge-to-v3.126.0` from `main`.
-
-### Pre-conditions confirmed during Phase 0
-
-- `provider/resources.go` already uses correct import `v3/pkg/pf/tfbridge` ✅
-- The standalone `/pf` require in `go.mod` is already removed ✅
-- These changes are in the Phase 0 PR, so after merge the main branch will be clean
-
-### Manual changes required (upgrade-provider CLI will NOT do these)
-
-**a) `mise.toml`** — bump Go version (if present):
-```toml
-# before
-go = "1.23"
-# after
-go = "1.25"
-```
-
-**b) `.github/workflows/pull-request.yml`** — bump Go in matrix:
-```yaml
-goversion:
-  - 1.25.x   # was 1.23.x
-```
-
-**c) `provider/go.mod`** — bridge v3.111.0 → v3.126.0 requires Go 1.25:
-```
-go 1.25
-toolchain go1.25.x
-```
-
-### Use upgrade-provider CLI for go.mod + regeneration
-
-```bash
-git checkout main && git pull origin main
-git checkout -b upgrade-bridge-to-v3.126.0
-mise install   # installs Go 1.25 and other tools
-
-# Apply manual changes above first, then:
-upgrade-provider ryan-pip/pulumi-fivetran \
-  --kind=bridge \
-  --target-bridge-version=v3.126.0
-```
-
-The CLI updates `provider/go.mod` (bridge v3.111.0→v3.126.0), runs `go mod tidy`,
-runs `make generate`, commits, pushes.
-
-### Validation checklist
-1. `go build ./...` succeeds
-2. `go vet ./...` passes
-3. `golangci-lint` passes
-4. `make schema` generates without error
-5. Schema resource count > 0
-6. Worktree-clean check passes (committed schema matches generated)
-7. All SDK builds pass
-8. Manual: compare `schema.json` before/after — bridge upgrade should produce minimal
-   schema changes (formatting only, no resource additions/removals)
-
-### What "broken" looks like
-- Build fails → `/pf` import not fully migrated (grep: `grep -r "terraform-bridge/pf"`)
-- `make schema` fails → bridge API incompatibility; check bridge CHANGELOG for breaking changes
-- Schema has 0 resources → tfgen crashed silently; inspect stderr from schema generation
-- SDK builds fail after schema succeeds → codegen template change in new bridge
-- Lint fails → new bridge code exposed previously-hidden linting issues
-
----
-
-## Phase 3 — Provider Upgrade v1.9.4 → v1.9.29
-
-**Blocked until Phase 2 is merged to main.**
-Branch: `upgrade-provider-to-v1.9.29` from `main`.
-
-```bash
-git checkout main && git pull origin main
-upgrade-provider ryan-pip/pulumi-fivetran \
-  --kind=provider \
-  --target-version=v1.9.29
-```
-
-The CLI updates `provider/go.mod` and `provider/shim/go.mod`
-(fivetran v1.9.4→v1.9.29), runs `go mod tidy` in both, runs `make generate`,
-commits, pushes, and creates PR.
-
-### Manual fallback (if CLI fails or doesn't handle shim)
-
-```bash
-git checkout -b upgrade-provider-to-v1.9.29
-
-cd provider/shim
-go get github.com/fivetran/terraform-provider-fivetran@v1.9.29
-go mod tidy
-
-cd ../..
-cd provider
-go get github.com/fivetran/terraform-provider-fivetran@v1.9.29
-go mod tidy
-
-make generate
-git add -A
-git commit -m "Upgrade terraform-provider-fivetran to v1.9.29"
-git push -u origin upgrade-provider-to-v1.9.29
-```
-
-### Validation for provider upgrade
-- Schema WILL change (new resources/properties in v1.9.29 vs v1.9.4) — this is expected
-- Review fivetran terraform-provider CHANGELOG from v1.9.4 to v1.9.29:
-  - Any **removed resources** → existing users' stacks would fail on next `pulumi up`
-  - Any **renamed resources** → may need aliases in `resources.go`
-  - Any **type changes on required fields** → potential state corruption
-- Schema resource count must be ≥ count from v1.9.4 (resources are rarely removed)
-
----
-
-## Phase 4 — Ongoing Automation (self-maintaining after all PRs land)
-
-After all three PRs merge:
-1. Daily `upgrade-provider.yml` runs at 05:00 UTC
-2. Detects new upstream versions and creates PRs automatically
-3. Those PRs go through lint + vet + unit-test + schema-validation + build
-4. If CI passes, review and merge; if CI fails, the failure is meaningful
-
-No further changes required.
-
----
-
-## Out of Scope
-
-**Integration tests against real Fivetran API**: Requires `FIVETRAN_APIKEY` and
-`FIVETRAN_APISECRET` secrets. The `examples/` directory has the framework but no test
-programs. Add as a future PR once credentials are available in GitHub secrets.
-
----
-
-## Key Files
-
-| File | Phase | Change |
-|---|---|---|
-| `.golangci.yml` | 0 ✅ | Fixed 6 deprecated linters, golangci-lint v2 format |
-| `.github/workflows/pull-request.yml` | 0 ✅ | Added lint/unit-test/schema-validation jobs |
-| `.github/workflows/upgrade-provider.yml` | 0 ✅ | Updated action to `@v1` |
-| `provider/go.mod` | 0 ✅ | Removed standalone `/pf` bridge require |
-| `mise.toml` | 2 | Go 1.23 → 1.25 |
-| `provider/go.mod` | 2 | Bridge v3.111.0 → v3.126.0, Go 1.25 |
-| `provider/go.mod` + `provider/shim/go.mod` | 3 | Fivetran v1.9.4 → v1.9.29 |
-
-## Execution Order
-
-```
-Phase 0 (repo uplift — branch ready, needs PR+merge)
-Phase 1 (branch cleanup — can run any time)
-     │
-     ▼ (after Phase 0 lands on main)
-Phase 2 (bridge upgrade v3.111.0 → v3.126.0)
-     │
-     ▼ (after Phase 2 lands on main)
-Phase 3 (provider upgrade v1.9.4 → v1.9.29)
-     │
-     ▼
-Phase 4 (ongoing automation — no action needed)
-```
+- Project rules: [.claude/rules/](.claude/rules/)
+- Repeatable SDK regen workflow: [.claude/skills/regenerate-sdks/SKILL.md](.claude/skills/regenerate-sdks/SKILL.md)
+- Full migration plan (with rationale, file inventories, exact substitutions):
+  `~/.claude/plans/i-started-getting-this-tranquil-sparkle.md`

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,19 @@
+"""Pulumi mock runtime for SDK smoke tests.
+
+Set up before any pulumi_provider_fivetran import so resource registrations
+go through MockRuntime instead of trying to talk to a real engine.
+"""
+
+import pulumi
+
+
+class _FivetranMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        # Echo inputs back as outputs; assign a deterministic ID derived from name.
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        return {}
+
+
+pulumi.runtime.set_mocks(_FivetranMocks(), preview=False)

--- a/tests/python/pyproject.toml
+++ b/tests/python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "pulumi-fivetran-tests"
+version = "0.0.0"
+description = "SDK smoke tests for pulumi-fivetran (mocked runtime, no live API calls)"
+requires-python = ">=3.9"
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = ["test_*.py"]
+addopts = "-ra --strict-markers"

--- a/tests/python/test_smoke.py
+++ b/tests/python/test_smoke.py
@@ -1,0 +1,107 @@
+"""SDK smoke tests.
+
+Each test constructs one resource via the mocked Pulumi runtime and asserts
+that the URN and a representative output property resolve. Catches:
+  - SDK build/import broken
+  - __init__ signature drift after a bridge bump
+  - Property serialization failures in the bridge layer
+
+These tests do NOT exercise real Fivetran API calls — see examples/ for live
+integration scaffolding.
+"""
+
+import pulumi
+import pulumi_provider_fivetran as fivetran
+
+
+def _check_urn(resource):
+    """Return an Output[None] that asserts the resource registered with a URN."""
+
+    def check(urn):
+        assert urn, f"empty URN for {resource}"
+
+    return resource.urn.apply(check)
+
+
+def test_module_imports():
+    expected = {
+        "Connector",
+        "Destination",
+        "ExternalLogging",
+        "Group",
+        "Team",
+        "Transformation",
+        "TransformationProject",
+        "User",
+        "Webhook",
+    }
+    missing = expected - set(dir(fivetran))
+    assert not missing, f"missing exports: {missing}"
+
+
+@pulumi.runtime.test
+def test_group():
+    g = fivetran.Group("smoke-group", name="smoke-group")
+    return _check_urn(g)
+
+
+@pulumi.runtime.test
+def test_destination():
+    d = fivetran.Destination(
+        "smoke-destination",
+        group_id="g_xyz",
+        service="snowflake",
+        region="GCP_US_EAST4",
+        time_zone_offset="-5",
+    )
+    return _check_urn(d)
+
+
+@pulumi.runtime.test
+def test_connector():
+    c = fivetran.Connector(
+        "smoke-connector",
+        group_id="g_xyz",
+        service="postgres",
+    )
+    return _check_urn(c)
+
+
+@pulumi.runtime.test
+def test_user():
+    u = fivetran.User(
+        "smoke-user",
+        email="smoke@example.com",
+        given_name="Smoke",
+        family_name="Test",
+    )
+    return _check_urn(u)
+
+
+@pulumi.runtime.test
+def test_team():
+    t = fivetran.Team("smoke-team", role="Account Reviewer")
+    return _check_urn(t)
+
+
+@pulumi.runtime.test
+def test_transformation_project():
+    p = fivetran.TransformationProject(
+        "smoke-project",
+        group_id="g_xyz",
+        type="DBT_GIT",
+    )
+    return _check_urn(p)
+
+
+@pulumi.runtime.test
+def test_webhook():
+    w = fivetran.Webhook(
+        "smoke-webhook",
+        active=True,
+        events=["sync_start"],
+        secret="redacted",
+        type="account",
+        url="https://example.com/hook",
+    )
+    return _check_urn(w)


### PR DESCRIPTION
## Summary

Stacked on #47 (now merged). This PR brings the CI pipelines + auto-tag mirror + Python smoke tests in line with `pulumi-astronomer`.

### CI overhaul

- **`.github/actions/`** — 3 composite actions: `setup-mise` (CI subset of mise.toml), `upload-prerequisites` + `download-prerequisites` (share the prebuilt provider binary across jobs)
- **`pull-request.yml`** — parallel `lint` / `schema_validation` / `go_test`; single `prerequisites` build; matrix `build_sdk` (4 langs) using `make --touch` to skip rebuilds; `python_tests` runs `make test_python_smoke`
- **`release.yml`** — 6-shard goreleaser parallel build (linux/darwin/windows × amd64/arm64), publish_release assembles archives, per-language SDK publish via **OIDC trusted publishing** for npm + PyPI (drops `NPM_TOKEN` dependency)
- **`upgrade-provider.yml`** — inlined `upgrade-provider` CLI; auto-merge gated by BOTH bot author + upgrade-* branch prefix
- **`auto-tag.yml`** — NEW; mirrors upstream `terraform-provider-fivetran` tags when `provider/shim/go.mod` changes (note: `shim` — fivetran's upstream is in the shim go.mod, not `provider/go.mod`). Uses RELEASE_BOT GitHub App.

### Tests

- `tests/python/` NEW: pyproject.toml + conftest.py + test_smoke.py (8 tests covering imports + Group, Destination, Connector, User, Team, TransformationProject, Webhook construction via Pulumi mock runtime)
- `make test_python_smoke` ✅ all 8 tests pass locally
- `.gitignore`: add Python test artifacts (`__pycache__`, `.venv`)

## Test plan

- [x] Local `make test_python_smoke` passes (8/8)
- [x] `hk run check --all` passes
- [ ] Verify all CI jobs run and pass on this PR

## Setup follow-ups (out of scope for this PR)

- Configure Trusted Publishers on npm (`@ryan-pip/pulumi-fivetran`) and PyPI (`pulumi_provider_fivetran`) before the next release tag.
- Provision pulumi-release-bot GitHub App, install on repo, set `vars.RELEASE_BOT_APP_ID` + `secrets.RELEASE_BOT_PRIVATE_KEY` (required for auto-tag.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)