### PR TITLE
fix: correct provider Repository URL to match the actual GitHub user

### DIFF
--- a/provider/resources.go
+++ b/provider/resources.go
@@ -98,7 +98,7 @@ func Provider() tfbridge.ProviderInfo {
 		Keywords:   []string{"pulumi", "fivetran", "category/utility"},
 		License:    "Apache-2.0",
 		Homepage:   "https://www.pulumi.com",
-		Repository: "https://github.com/ryan-packer/pulumi-fivetran",
+		Repository: "https://github.com/ryan-pip/pulumi-fivetran",
 		// The GitHub Org for the provider - defaults to `terraform-providers`. Note that this
 		// should match the TF provider module's require directive, not any replace directives.
 		Version:      version.Version,

--- a/sdk/dotnet/Pulumi.Fivetran.csproj
+++ b/sdk/dotnet/Pulumi.Fivetran.csproj
@@ -7,7 +7,7 @@
     <Description>A Pulumi package for creating and managing fivetran cloud resources.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://www.pulumi.com</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/ryan-packer/pulumi-fivetran</RepositoryUrl>
+    <RepositoryUrl>https://github.com/ryan-pip/pulumi-fivetran</RepositoryUrl>
     <PackageIcon>logo.png</PackageIcon>
 
     <TargetFramework>net6.0</TargetFramework>

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -1,4 +1,4 @@
 > This provider is a derived work of the [Terraform Provider](https://github.com/fivetran/terraform-provider-fivetran)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
-> first check the [`pulumi-fivetran` repo](https://github.com/ryan-packer/pulumi-fivetran/issues); however, if that doesn't turn up anything,
+> first check the [`pulumi-fivetran` repo](https://github.com/ryan-pip/pulumi-fivetran/issues); however, if that doesn't turn up anything,
 > please consult the source [`terraform-provider-fivetran` repo](https://github.com/fivetran/terraform-provider-fivetran/issues).

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -8,7 +8,7 @@
         "category/utility"
     ],
     "homepage": "https://www.pulumi.com",
-    "repository": "https://github.com/ryan-packer/pulumi-fivetran",
+    "repository": "https://github.com/ryan-pip/pulumi-fivetran",
     "license": "Apache-2.0",
     "scripts": {
         "build": "tsc"

--- a/sdk/python/pulumi_provider_fivetran/README.md
+++ b/sdk/python/pulumi_provider_fivetran/README.md
@@ -1,4 +1,4 @@
 > This provider is a derived work of the [Terraform Provider](https://github.com/fivetran/terraform-provider-fivetran)
 > distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,
-> first check the [`pulumi-fivetran` repo](https://github.com/ryan-packer/pulumi-fivetran/issues); however, if that doesn't turn up anything,
+> first check the [`pulumi-fivetran` repo](https://github.com/ryan-pip/pulumi-fivetran/issues); however, if that doesn't turn up anything,
 > please consult the source [`terraform-provider-fivetran` repo](https://github.com/fivetran/terraform-provider-fivetran/issues).

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -10,7 +10,7 @@
     text = "Apache-2.0"
   [project.urls]
     Homepage = "https://www.pulumi.com"
-    Repository = "https://github.com/ryan-packer/pulumi-fivetran"
+    Repository = "https://github.com/ryan-pip/pulumi-fivetran"
 
 [build-system]
   requires = ["setuptools>=61.0"]


### PR DESCRIPTION
## Summary

The npm publish for [v1.9.4-alpha.1](https://github.com/ryan-pip/pulumi-fivetran/actions/runs/25108994412) failed at provenance validation because the package.json repository.url didn't match the URL the npm provenance attestation derives from GitHub Actions:

\`\`\`
npm error 422 Unprocessable Entity
Error verifying sigstore provenance bundle: Failed to validate repository information ...
expected to match "https://github.com/ryan-pip/pulumi-fivetran" from provenance
\`\`\`

The provenance attestation reflects the actual repository (\`ryan-pip\`), but the \`Repository\` field in [provider/resources.go:101](provider/resources.go#L101) had a typo'd GitHub user, so the generated SDK manifests embedded the wrong URL. With \`--provenance\`, npm requires the two to match exactly.

## Changes

- \`provider/resources.go\`: corrected the \`Repository\` URL
- regenerated \`schema.json\` + all 4 SDKs to pick up the corrected URL

## Test plan

- [x] \`make schema build_sdks\` clean
- [ ] Re-tag (e.g. \`v1.9.4-alpha.2\`) after this lands; npm publish should succeed

Note: PyPI publish for v1.9.4-alpha.1 succeeded, so Trusted Publishing is already configured there. The npm Trusted Publisher also appears configured (the failure was provenance URL mismatch, not auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)