### PR TITLE
ci(upgrade-provider): auto-sync go.work go directive after bumps

### DIFF
--- a/.claude/rules/bridge-upgrade-flow.md
+++ b/.claude/rules/bridge-upgrade-flow.md
@@ -22,9 +22,12 @@ Phased, **one PR per concern**. The git history shows the pattern (e.g. `phase 0
 
 ```bash
 cd provider && go mod tidy
+make sync-go-work    # bridge bumps may raise provider/go.mod's `go` directive
 make schema build_sdks
-git status        # confirm only the expected files changed
+git status           # confirm only the expected files changed
 ```
+
+`make sync-go-work` aligns `go.work`'s `go` directive with the highest among the workspace modules. Skipping it leaves the workspace inconsistent and breaks `go vet`, `golangci-lint`, the provider build, and CodeQL autobuild on any PR that touched a module's `go` directive. The `upgrade-provider.yml` workflow runs the same sync automatically.
 
 For regen commits, the diff should be **only** generated files. If you see hand-written changes too, split them into a separate commit on the same branch.
 

--- a/.github/workflows/upgrade-provider.yml
+++ b/.github/workflows/upgrade-provider.yml
@@ -51,6 +51,34 @@ jobs:
         run: upgrade-provider "$GITHUB_REPOSITORY" --kind=all --allow-missing-docs=true --repo-path=.
         shell: bash
 
+      - name: Sync go.work go directive
+        # upgrade-provider bumps provider/go.mod's `go` directive when the new
+        # bridge requires it but doesn't know about the workspace. If go.work's
+        # `go` directive falls behind any module, every Go toolchain invocation
+        # against the workspace errors with "go.work lists go X.Y.Z" and breaks
+        # lint, go vet, build, and CodeQL autobuild on the bot's PR.
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          BRANCH=$(git branch --show-current)
+          case "$BRANCH" in
+            upgrade-pulumi-terraform-bridge-*|upgrade-terraform-provider-*|upgrade-pulumi-version-*) ;;
+            *) echo "branch $BRANCH not an upgrade branch; skipping"; exit 0 ;;
+          esac
+          MAX=$(awk '/^go [0-9]/ {print $2}' provider/go.mod provider/shim/go.mod sdk/go.mod | sort -V | tail -1)
+          CURRENT=$(awk '/^go [0-9]/ {print $2; exit}' go.work)
+          echo "go.work directive: $CURRENT, max module directive: $MAX"
+          if [ "$MAX" != "$CURRENT" ]; then
+            go work edit -go="$MAX"
+            git add go.work
+            git commit -m "chore: sync go.work go directive to $MAX"
+            git push
+          else
+            echo "go.work already at $MAX; nothing to do"
+          fi
+        shell: bash
+
       - name: Enable auto-merge on upgrade PR
         # safety filter — both bot author + branch prefix required
         env:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ _ := $(shell mkdir -p .make bin)
         build_nodejs build_python build_go build_dotnet \
         prepare_local_workspace test_python_smoke test_python \
         lint tidy fmt clean install_sdks install_nodejs_sdk \
-        install_python_sdk install_go_sdk install_dotnet_sdk
+        install_python_sdk install_go_sdk install_dotnet_sdk \
+        sync-go-work
 
 # ── top-level aliases ─────────────────────────────────────────────────────────
 
@@ -153,6 +154,20 @@ lint:
 
 tidy:
 	find ./provider -name go.mod -execdir go mod tidy \;
+
+# Aligns go.work's `go` directive with the highest `go` directive among the
+# workspace modules. Run after bumping pulumi-terraform-bridge (which can pull
+# a new minimum Go) so `go vet`, `golangci-lint`, and the provider build
+# don't fail with "go.work lists go X.Y.Z".
+sync-go-work:
+	@MAX=$$(awk '/^go [0-9]/ {print $$2}' provider/go.mod provider/shim/go.mod sdk/go.mod | sort -V | tail -1); \
+	 CURRENT=$$(awk '/^go [0-9]/ {print $$2; exit}' go.work); \
+	 if [ "$$MAX" != "$$CURRENT" ]; then \
+	   echo "Updating go.work go directive: $$CURRENT -> $$MAX"; \
+	   go work edit -go="$$MAX"; \
+	 else \
+	   echo "go.work already at $$MAX"; \
+	 fi
 
 fmt:
 	find . -name '*.go' | grep -v vendor | xargs gofmt -s -w


### PR DESCRIPTION
Bridge bumps that raise provider/go.mod's `go` directive (e.g. v3.129.2
requires Go 1.25.9) leave go.work behind, which causes every Go toolchain
invocation against the workspace to fail with "go.work lists go X.Y.Z" and
breaks lint, go vet, build, and CodeQL autobuild on the bot's PR.

Add a workflow step that aligns go.work to max(provider, shim, sdk) after
upgrade-provider runs, plus a `make sync-go-work` target for parity with
local upgrade flows.