### PR TITLE
ci: attribute auto-tag mirror tags to this repo's release-bot app

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -47,8 +47,15 @@ jobs:
         if: steps.decide.outputs.tag != ''
         env:
           TAG: ${{ steps.decide.outputs.tag }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git config user.name 'pulumi-release-bot[bot]'
-          git config user.email 'pulumi-release-bot[bot]@users.noreply.github.com'
+          set -euo pipefail
+          # Use this repo's own release-bot app identity (the app that minted the
+          # token above), derived from its app-slug — not upstream's hardcoded
+          # pulumi-release-bot.
+          NAME="${{ steps.app-token.outputs.app-slug }}[bot]"
+          ID=$(gh api "/users/${NAME}" --jq .id)
+          git config user.name "$NAME"
+          git config user.email "${ID}+${NAME}@users.noreply.github.com"
           git tag -a "$TAG" -m "chore(release): $TAG (mirror upstream terraform-provider-fivetran)"
           git push origin "$TAG"

--- a/openspec/changes/fix-auto-tag-git-identity/.openspec.yaml
+++ b/openspec/changes/fix-auto-tag-git-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/fix-auto-tag-git-identity/design.md
+++ b/openspec/changes/fix-auto-tag-git-identity/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`auto-tag.yml` and `upgrade-provider.yml` are siblings: both mint a token from this repo's release-bot GitHub App via `actions/create-github-app-token` (using `vars.RELEASE_BOT_APP_ID` / `secrets.RELEASE_BOT_PRIVATE_KEY`) and use it to push to the repo. `upgrade-provider.yml`'s `Set up git identity` step was de-hardcoded to derive the committer identity from the minting app:
+
+```bash
+NAME="${{ steps.app-token.outputs.app-slug }}[bot]"
+ID=$(gh api "/users/${NAME}" --jq .id)
+git config --global user.name "$NAME"
+git config --global user.email "${ID}+${NAME}@users.noreply.github.com"
+```
+
+`auto-tag.yml`'s `Push tag` step was never updated and still runs:
+
+```bash
+git config user.name 'pulumi-release-bot[bot]'
+git config user.email 'pulumi-release-bot[bot]@users.noreply.github.com'
+```
+
+The app behind `RELEASE_BOT_APP_ID` is this repo's own app, whose slug is not necessarily `pulumi-release-bot`, and the canonical noreply address for a GitHub App bot is `<numeric-id>+<slug>[bot]@users.noreply.github.com` — neither of which the hardcoded values match. (This repo's `auto-tag` triggers on `provider/shim/go.mod` bumps; the trigger is unrelated to the fix and stays as-is.)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make `auto-tag.yml`'s tagger identity match the app that actually pushes the tag, so tags are correctly attributed and verified.
+- Use the exact derivation already proven in `upgrade-provider.yml`, so the two workflows stay consistent.
+
+**Non-Goals:**
+- Changing when or whether tags are pushed (the trigger, version-gate, and existing-tag guard are unchanged).
+- Touching `upgrade-provider.yml`, which already does this correctly.
+- Signing tags (GPG/SSH) — out of scope; this only fixes the tagger identity.
+
+## Decisions
+
+**Derive the identity at run time from `app-slug`, matching `upgrade-provider.yml` verbatim.** The token is minted earlier in the same job (`id: app-token`), so `steps.app-token.outputs.app-slug` is available, and `gh api /users/<slug>[bot]` returns the bot user's numeric id. Reusing the identical snippet (rather than inventing a new mechanism) keeps the two workflows aligned and makes the spec's "same as upgrade-provider" requirement literally true.
+
+- _Alternative — hardcode the correct slug/id once:_ rejected. It re-introduces the same brittleness we removed from `upgrade-provider.yml`; if the app is ever rotated or renamed, the value drifts silently.
+- _Alternative — drop annotation, push a lightweight tag with no tagger:_ rejected. Annotated tags carry the `chore(release): ...` message used downstream; we only want to fix the identity, not change the tag object.
+
+**Add `GH_TOKEN` to the `Push tag` step's `env`.** The step currently only sets `TAG`. The `gh api` lookup needs authentication; the minted app token is the natural choice and is already in scope.
+
+## Risks / Trade-offs
+
+- [The `gh api /users/<slug>[bot]` lookup fails or rate-limits] → With `GH_TOKEN` set to the app token the call is authenticated and the per-run cost is a single request; `upgrade-provider.yml` already relies on the identical call without issue.
+- [`app-slug` output differs from expectation] → That is precisely the bug being fixed: the derived value is authoritative for whichever app `RELEASE_BOT_APP_ID` points at, so using it is correct by construction.
+
+## Migration Plan
+
+Single-commit workflow edit; no data or state migration. Takes effect on the next `auto-tag-upstream-bump` run (next upstream bump merged to `main`). Rollback is reverting the one commit. Prior tags are unaffected.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-auto-tag-git-identity/proposal.md
+++ b/openspec/changes/fix-auto-tag-git-identity/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+`auto-tag.yml`'s `Push tag` step hardcodes the upstream `pulumi-release-bot[bot]` git identity, even though the token it pushes with is minted from **this repo's own** release-bot GitHub App (`vars.RELEASE_BOT_APP_ID`). The sibling `upgrade-provider.yml` was deliberately de-hardcoded to derive its committer identity from the app that mints the token (`steps.app-token.outputs.app-slug` + the app user's id), and the `ci-cd-pipelines` spec already requires that. `auto-tag.yml` was left behind, so every mirror tag it pushes is annotated with a fabricated tagger — a bare `pulumi-release-bot[bot]@users.noreply.github.com` with no numeric app id, for an app whose real slug is whatever this repo's `RELEASE_BOT_APP_ID` resolves to. The tag push still succeeds, but the tagger is misattributed and unverified, and it silently contradicts the identity used everywhere else in the same workflow family.
+
+## What Changes
+
+- Replace the two hardcoded `git config` lines in `auto-tag.yml`'s `Push tag` step with the same dynamic derivation `upgrade-provider.yml` uses: `NAME="${{ steps.app-token.outputs.app-slug }}[bot]"`, `ID=$(gh api "/users/${NAME}" --jq .id)`, then `git config user.name "$NAME"` and `git config user.email "${ID}+${NAME}@users.noreply.github.com"`.
+- The `Push tag` step gains `GH_TOKEN: ${{ steps.app-token.outputs.token }}` in its `env` so the `gh api` lookup is authenticated (the app token is already minted earlier in the job).
+- Extend the `ci-cd-pipelines` capability with a requirement that `auto-tag.yml` (like `upgrade-provider.yml`) attribute its tags to this repo's own bot identity and never hardcode the upstream `pulumi-release-bot` identity.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `ci-cd-pipelines`: add a requirement that the `auto-tag-upstream-bump` workflow attribute mirror tags to this repo's own release-bot identity, derived from the token-minting app's `app-slug`, rather than the hardcoded upstream `pulumi-release-bot` identity.
+
+## Impact
+
+- Modified: `.github/workflows/auto-tag.yml` (the `Push tag` step only).
+- CI/release tooling only — no provider runtime or SDK behavior change. Tags are still pushed on the same trigger (`provider/shim/go.mod` bumps); only the tagger identity becomes correct and verified.
+- Part of the two-repo effort to keep `pulumi-astronomer` and `pulumi-fivetran` on the same bot-identity pattern; each carries its own repo-local change.

--- a/openspec/changes/fix-auto-tag-git-identity/specs/ci-cd-pipelines/spec.md
+++ b/openspec/changes/fix-auto-tag-git-identity/specs/ci-cd-pipelines/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Auto-tag uses this repo's own bot identity
+
+`auto-tag.yml` (the `auto-tag-upstream-bump` workflow) SHALL attribute the mirror tags it pushes to this repo's release-bot GitHub App identity — the app that mints the token via `actions/create-github-app-token` — derived dynamically from that step's `app-slug` output, and SHALL NOT hardcode the upstream `pulumi-release-bot` identity. The `Push tag` step SHALL set `user.name = "<app-slug>[bot]"` with the matching noreply `user.email` of the form `<bot-user-id>+<app-slug>[bot]@users.noreply.github.com`, where `<bot-user-id>` is resolved from the GitHub API for that bot user. The step SHALL pass the minted app token as `GH_TOKEN` so the API lookup is authenticated. This mirrors the identity derivation already required of `upgrade-provider.yml`.
+
+#### Scenario: tags are attributed to this repo's bot
+
+- **WHEN** the `auto-tag-upstream-bump` workflow configures git identity before pushing a mirror tag
+- **THEN** `user.name` is `<app-slug>[bot]` for this repo's app and `user.email` is the matching `<bot-user-id>+<app-slug>[bot]@users.noreply.github.com`, not `pulumi-release-bot[bot]`
+
+#### Scenario: the bot-user-id lookup is authenticated
+
+- **WHEN** the `Push tag` step resolves the bot user's id via `gh api`
+- **THEN** the step has `GH_TOKEN` set to the minted app token so the lookup succeeds

--- a/openspec/changes/fix-auto-tag-git-identity/tasks.md
+++ b/openspec/changes/fix-auto-tag-git-identity/tasks.md
@@ -1,0 +1,11 @@
+## 1. Fix the auto-tag git identity
+
+- [x] 1.1 In `.github/workflows/auto-tag.yml`, add `GH_TOKEN: ${{ steps.app-token.outputs.token }}` to the `Push tag` step's `env` (alongside the existing `TAG`).
+- [x] 1.2 In the `Push tag` step's run script, replace the two hardcoded `git config` lines with the dynamic derivation used by `upgrade-provider.yml`: set `NAME="${{ steps.app-token.outputs.app-slug }}[bot]"`, `ID=$(gh api "/users/${NAME}" --jq .id)`, then `git config user.name "$NAME"` and `git config user.email "${ID}+${NAME}@users.noreply.github.com"`.
+- [x] 1.3 Add a brief comment above the identity block (mirroring `upgrade-provider.yml`) explaining it uses this repo's own release-bot app identity, not the hardcoded upstream `pulumi-release-bot`.
+
+## 2. Verify
+
+- [x] 2.1 Confirm the `Push tag` step's identity derivation matches `upgrade-provider.yml`'s `Set up git identity` step (same `app-slug`/`gh api`/email format), so the two workflows are consistent.
+- [x] 2.2 Lint the workflow (`actionlint .github/workflows/auto-tag.yml`) and confirm no YAML/shell issues.
+- [x] 2.3 Sanity-check the rest of the `Push tag` step is unchanged: same trigger (`provider/shim/go.mod`), version-gate, existing-tag guard, and annotated `git tag -a ... -m "chore(release): ..."` message.


### PR DESCRIPTION
## Why

`auto-tag.yml`'s `Push tag` step hardcoded the upstream `pulumi-release-bot[bot]` git identity, even though it pushes with a token minted from **this repo's own** release-bot GitHub App (`vars.RELEASE_BOT_APP_ID`). The sibling `upgrade-provider.yml` was already de-hardcoded to derive its committer identity from the minting app's `app-slug`; `auto-tag.yml` was left behind.

Result: every mirror tag was annotated with a fabricated tagger — a bare `pulumi-release-bot[bot]@users.noreply.github.com` with no numeric app id, for an app whose real slug is whatever `RELEASE_BOT_APP_ID` resolves to. The tag push still succeeded, but the tagger was misattributed and unverified, silently contradicting the identity used everywhere else in the same workflow family.

## What changed

`.github/workflows/auto-tag.yml` — `Push tag` step only:

- Added `GH_TOKEN: ${{ steps.app-token.outputs.token }}` to `env` so the `gh api` lookup is authenticated.
- Replaced the two hardcoded `git config` lines with the same derivation `upgrade-provider.yml` uses:
  ```bash
  NAME="${{ steps.app-token.outputs.app-slug }}[bot]"
  ID=$(gh api "/users/${NAME}" --jq .id)
  git config user.name "$NAME"
  git config user.email "${ID}+${NAME}@users.noreply.github.com"
  ```
- Trigger, version-gate, existing-tag guard, and the annotated `git tag -a … -m "chore(release): …"` message are unchanged.

Also includes the OpenSpec change `fix-auto-tag-git-identity` (proposal, design, `ci-cd-pipelines` spec delta adding the "auto-tag uses this repo's own bot identity" requirement, tasks).

## Verification

- `actionlint .github/workflows/auto-tag.yml` passes clean.
- Identity derivation confirmed consistent with this repo's `upgrade-provider.yml`.

CI/release tooling only — no provider runtime or SDK behavior change. Part of a two-repo fix; the parallel change lands in the other provider repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
