### PR TITLE
ci: unblock daily upgrade-provider (GOTOOLCHAIN auto)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -16,4 +16,4 @@ golangci-lint = "2"
 "go:github.com/pulumi/pulumictl/cmd/pulumictl" = "latest"
 
 [env]
-GOTOOLCHAIN = "go1.25.9"
+GOTOOLCHAIN = "auto" # Never exact-pin: drift vs mise.lock's go version has repeatedly broken the daily upgrade-provider workflow.

--- a/openspec/changes/unblock-daily-upgrade-provider/.openspec.yaml
+++ b/openspec/changes/unblock-daily-upgrade-provider/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/unblock-daily-upgrade-provider/design.md
+++ b/openspec/changes/unblock-daily-upgrade-provider/design.md
@@ -1,0 +1,31 @@
+# Design — unblock-daily-upgrade-provider (fivetran)
+
+## Context
+
+Mirror of the pulumi-astronomer change of the same name; see that repo's `openspec/changes/unblock-daily-upgrade-provider/design.md` for the full diagnosis and verification record. Summary: the daily `upgrade-provider` job fails at `go get pulumi-terraform-bridge/v3` because bridge v3.134.0 requires go ≥ 1.25.11 while `mise.toml` `[env]` pins `GOTOOLCHAIN = "go1.25.9"` — an exact-version duplicate of what `mise.lock` pins (go 1.25.11) that has drifted. mise shims re-export `[env]` over the caller's environment, so the pin cannot be overridden per-step. This repo has no second failure: upstream `terraform-provider-fivetran` has no pending tag (the failing runs never enter the `Update TF Provider` phase).
+
+## Goals / Non-Goals
+
+**Goals:** daily automation green; one pinned source of the installed Go version (`mise.lock`); no recurrence when the bridge next adopts a Go patch release.
+
+**Non-Goals:** workflow YAML changes; bumping bridge/upstream by hand (the bot does that once unblocked).
+
+## Decisions
+
+### D1: `GOTOOLCHAIN = "auto"` (not `local`, not a fresher exact pin)
+
+Same decision and rationale as the astronomer sibling: an exact pin recreates this incident on next drift; `local` still hard-fails whenever the bridge requires newer Go than the lockfile (nothing automated bumps `mise.lock`); `auto` satisfies future requirements by downloading the exact sumdb-checksummed toolchain, with the requirement recorded in committed `go` directives. Verified against bridge v3.134.0 in the astronomer worktree (identical mise layout and pin).
+
+## Risks / Trade-offs
+
+Same as the sibling: [toolchain may be downloaded newer than mise.lock's] → checksummed, directive-pinned in git, re-synced by periodic `mise up`; [golangci-lint lagging a new Go language version] → pre-existing under any setting, surfaces as a red PR check.
+
+## Migration Plan
+
+1. One-line PR changing the mise env value.
+2. Next scheduled run should open the bridge v3.134.0 upgrade PR (go directive bump + go.work sync included) and auto-merge per the existing safety filters.
+3. Rollback: revert the line.
+
+## Open Questions
+
+None.

--- a/openspec/changes/unblock-daily-upgrade-provider/proposal.md
+++ b/openspec/changes/unblock-daily-upgrade-provider/proposal.md
@@ -1,0 +1,25 @@
+# Unblock daily upgrade-provider: Go toolchain drift
+
+## Why
+
+The scheduled `upgrade-provider` workflow has failed every day since 2026-07-11. `mise.toml` `[env]` hard-pins `GOTOOLCHAIN = "go1.25.9"` — a second, hand-maintained copy of the Go version that `mise.lock` already pins (currently go 1.25.11). Bridge v3.134.0 declares `go >= 1.25.11`, so the workflow's `go get pulumi-terraform-bridge/v3` hard-fails: `requires go >= 1.25.11 (running go 1.25.9; GOTOOLCHAIN=go1.25.9)`. Because mise shims re-export `[env]` over the caller's environment, the pin is absolute in CI. The pin has needed hand bumps repeatedly; the failure class recurs every time the bridge adopts a newer Go patch release. (Sibling change of the same name in pulumi-astronomer, which additionally has a C# codegen collision; this repo needs only the toolchain fix — its upstream has no pending tag.)
+
+## What Changes
+
+- Replace `GOTOOLCHAIN = "go1.25.9"` with `GOTOOLCHAIN = "auto"` in `mise.toml` `[env]`, removing the duplicated exact Go version. `mise.lock` stays the single pinned source of the installed toolchain; module `go` directives (managed by `go get`/upgrade-provider and the workflow's go.work sync step) declare the minimum, and Go resolves/downloads a newer checksummed toolchain only when a module requires it. Verified in the astronomer sibling (identical mise layout, same bridge target): with `auto`, `go get pulumi-terraform-bridge/v3@v3.134.0` succeeds, bumps the module `go` directive to 1.25.11, and the workspace builds.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `developer-tooling`: new requirement — the mise env SHALL NOT hard-pin an exact Go toolchain (`GOTOOLCHAIN` = exact version). Toolchain selection SHALL be `auto` so the exact installed version is pinned in one place (`mise.lock`) and module `go` directives can pull a newer toolchain without manual intervention.
+
+## Impact
+
+- `mise.toml` (`[env]` block) — one-line change; affects every mise-run Go invocation (CI and dev).
+- No workflow YAML changes. The existing `Sync go.work go directive` step already handles the directive skew the bridge bump creates.
+- Risk note: with `auto`, CI may download a Go toolchain newer than `mise.lock`'s (checksummed via the Go toolchain sumdb, recorded in committed `go` directives). `mise.lock` and `golangci-lint` should still be bumped periodically (`mise up`), but a stale lockfile no longer breaks the daily automation.

--- a/openspec/changes/unblock-daily-upgrade-provider/specs/developer-tooling/spec.md
+++ b/openspec/changes/unblock-daily-upgrade-provider/specs/developer-tooling/spec.md
@@ -1,0 +1,22 @@
+# developer-tooling — delta for unblock-daily-upgrade-provider
+
+## ADDED Requirements
+
+### Requirement: Go toolchain selection is not exact-pinned in mise env
+
+The mise `[env]` block SHALL set `GOTOOLCHAIN = "auto"` and SHALL NOT pin `GOTOOLCHAIN` to an exact Go version. The exact installed Go version SHALL be pinned in exactly one place — `mise.lock` — and module `go` directives (`provider/go.mod`, `provider/shim/go.mod`, `sdk/go.mod`, `go.work`) SHALL declare minimum-version requirements that the go command MAY satisfy by downloading a newer checksummed toolchain than the one mise installed.
+
+#### Scenario: bridge requires a newer Go than the installed toolchain
+
+- **WHEN** the daily upgrade workflow runs `go get github.com/pulumi/pulumi-terraform-bridge/v3@<new>` whose module declares `go >= X` with X newer than the mise-installed Go
+- **THEN** the go command resolves and downloads toolchain X automatically, the `go get` succeeds, and the `go` directive bump lands in the upgrade PR instead of the workflow hard-failing
+
+#### Scenario: installed toolchain satisfies the requirement
+
+- **WHEN** every module's `go` directive is satisfied by the mise-installed Go from `mise.lock`
+- **THEN** the go command uses the mise-installed toolchain with no download
+
+#### Scenario: no second copy of the Go version can drift
+
+- **WHEN** `mise.lock`'s Go version is bumped (e.g. by `mise up`)
+- **THEN** no other file in the repo holds an exact Go toolchain version that must be bumped in lockstep (`grep -r "GOTOOLCHAIN" mise*.toml` shows only `auto`)

--- a/openspec/changes/unblock-daily-upgrade-provider/tasks.md
+++ b/openspec/changes/unblock-daily-upgrade-provider/tasks.md
@@ -1,0 +1,12 @@
+# Tasks — unblock-daily-upgrade-provider (fivetran)
+
+## 1. Go toolchain fix
+
+- [x] 1.1 In `mise.toml` `[env]`, change `GOTOOLCHAIN = "go1.25.9"` to `GOTOOLCHAIN = "auto"` with a one-line comment stating why an exact pin is forbidden (drift vs `mise.lock` broke the daily upgrade)
+- [x] 1.2 Verify locally: `cd provider && go get github.com/pulumi/pulumi-terraform-bridge/v3@v3.134.0 && go mod tidy` succeeds and bumps the `go` directive to 1.25.11 (revert after verifying — the bot owns bridge bumps)
+
+## 2. PR + automation verification
+
+- [x] 2.1 Open the one-line PR (branch + Jira ref per repo conventions); confirm `pull-request.yml` is green
+- [ ] 2.2 After merge, confirm the next scheduled `upgrade-provider` run completes and opens the bridge v3.134.0 upgrade PR: `gh run list --workflow upgrade-provider.yml --limit 1`
+- [ ] 2.3 Confirm the bot PR auto-merges per the auto-merge safety filters (bot author + `upgrade-*` branch prefix) and its CI is green under the new toolchain setting

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven


### PR DESCRIPTION
## Root cause

The scheduled `upgrade-provider` workflow has failed every day since 2026-07-11. `mise.toml` `[env]` hard-pinned `GOTOOLCHAIN = "go1.25.9"` — a second, hand-maintained copy of the Go version that `mise.lock` already pins (go 1.25.11). Bridge v3.134.0 declares `go >= 1.25.11`, so the workflow's `go get pulumi-terraform-bridge/v3` hard-failed with `requires go >= 1.25.11 (running go 1.25.9; GOTOOLCHAIN=go1.25.9)`. Because mise shims re-export `[env]` over the caller's environment, the pin was absolute in CI. The pin has needed hand bumps repeatedly; the failure class recurs every time the bridge adopts a newer Go patch release.

## Fix

One line: `GOTOOLCHAIN = "auto"`. `mise.lock` stays the single pinned source of the installed toolchain; module `go` directives declare the minimum, and Go downloads a newer sumdb-checksummed toolchain only when a module requires it.

## Verification

Ran locally under the new setting: `cd provider && go get github.com/pulumi/pulumi-terraform-bridge/v3@v3.134.0 && go mod tidy` — succeeds and bumps the `go` directive to 1.25.11 (previously hard-failed). All verification changes were reverted before commit: this PR deliberately contains **no** bridge bump — the daily bot owns that, and the next scheduled run should open the bridge v3.134.0 upgrade PR itself.

## Spec

Approved openspec change: `openspec/changes/unblock-daily-upgrade-provider/` (proposal, design, tasks, `developer-tooling` spec delta). Sibling change of the same name in `pulumi-astronomer` (which additionally needs a C# codegen fix; this repo needs only the toolchain change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)